### PR TITLE
Update makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -7,7 +7,7 @@ USE_MKL       = 0
 # Set USE_SCALAPACK = 0 to compile with non-MKL BLAS and LAPACK only
 USE_SCALAPACK = 0
 # Set USE_DP_SUBEIG = 1 to use SPARC rather than ScaLAPACK routines for matrix data distribution
-# (Required if not using ScaLAPACK)
+# (USE_DP_SUBEIG = 1 is required if both USE_MKL = 0 and USE_SCALAPACK = 0)
 # Set USE_DP_SUBEIG = 0 to use ScaLAPACK rather than SPARC routines
 USE_DP_SUBEIG = 1
 # Set DEBUG_MODE = 1 to run with debug mode and print debug output


### PR DESCRIPTION
Modify the comment in the makefile to emphasize the requirement of setting `USE_DP_SUBEIG = 1` when both `USE_MKL` and `USE_SCALAPACK` are turned off.