### PR TITLE
fix bug in DP when domain parallel is on

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@
 
 
 --------------
+Aug 27, 2020
+Name: Qimen Xu
+Changes: (eigensolver.c, eigensolverKpt.c)
+1. Bug fix in DP: when DP is turned on and npdomain > 1, eigenvalues are only correct in the first dmcomm.
+
+
+--------------
 Jul 24, 2020
 Name: Qimen Xu, Abhiraj Sharma
 Changes: (eigensolver.c, stress.c)

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Jul 24, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Aug 27, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);


### PR DESCRIPTION
1. Bug fix in DP: when DP is turned on and npdomain > 1, eigenvalues are only correct in the first dmcomm.