### PR TITLE
add simd instructions for kpoint lapvec routines

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@
 
 
 --------------
+Sep 09, 2020
+Name: Qimen Xu
+Changes: (gradVecRoutinesKpt.c, lapVecNonOrthKpt.c, lapVecOrthKpt.c)
+1. Add simd instructions for Laplacian vector routines for k-points (works well for intel/19.0.5 with automatic cpu dispatch).
+
+
+--------------
 Aug 27, 2020
 Name: Qimen Xu
 Changes: (eigensolver.c, eigensolverKpt.c)

--- a/src/forces.c
+++ b/src/forces.c
@@ -845,7 +845,6 @@ void Calculate_local_forces_linear(SPARC_OBJ *pSPARC)
                         DVcJ_x_val = DVcJ_y_val = DVcJ_z_val = 0.0;
                         //bJ_val = VJ[ishift_p] * w2_diag;
                         //bJ_ref_val = VJ_ref[ishift_p] * w2_diag;
-                        //#pragma simd
                         for (p = 1; p <= FDn; p++) {
                             DVcJ_x_val += (VcJ[ishift_p+p] - VcJ[ishift_p-p]) * pSPARC->D1_stencil_coeffs_x[p];
                             DVcJ_y_val += (VcJ[ishift_p+pshifty_ex[p]] - VcJ[ishift_p-pshifty_ex[p]]) * pSPARC->D1_stencil_coeffs_y[p];

--- a/src/gradVecRoutinesKpt.c
+++ b/src/gradVecRoutinesKpt.c
@@ -437,22 +437,22 @@ void Calc_DX_kpt(
         {
             int jshift_DX = kshift_DX + j * stride_y_DX;
             int jshift_X = kshift_X + jj * stride_y_X;
-            //#pragma omp simd
-            init1 = 0;
-            for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
+            const int niters = x_DX_epos - x_DX_spos;
+            #pragma omp simd
+            for (i = 0; i < niters; i++)
             {
-                int ishift_DX = jshift_DX + i;
-                int ishift_X = jshift_X + ii;
-                count = init1 + init2 + init3;
+                int ishift_DX = jshift_DX + i + x_DX_spos;
+                int ishift_X = jshift_X + i + x_X_spos;
+                init1 = i * shift1;
+                int countshift = init1 + init2 + init3;
                 double complex temp = X[ishift_X] * c;
                 for (r = 1; r <= radius; r++)
                 {
                     int stride_X_r = r * stride_X;
+                    count = countshift + (r-1)*2;
                     temp += (X[ishift_X + stride_X_r] * Phase_fac[count] - X[ishift_X - stride_X_r] * Phase_fac[count + 1]) * stencil_coefs[r];
-                    count += 2;
                 }
                 DX[ishift_DX] = temp;
-                init1 += shift1;
             }
             init2 += shift2;
         }

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Sep 08, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Sep 09, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/initialization.c
+++ b/src/initialization.c
@@ -2208,7 +2208,7 @@ void write_output_init(SPARC_OBJ *pSPARC) {
     }
 
     fprintf(output_fp,"***************************************************************************\n");
-    fprintf(output_fp,"*                       SPARC (version Aug 27, 2020)                      *\n");  
+    fprintf(output_fp,"*                       SPARC (version Sep 08, 2020)                      *\n");  
     fprintf(output_fp,"*   Copyright (c) 2020 Material Physics & Mechanics Group, Georgia Tech   *\n");
     fprintf(output_fp,"*           Distributed under GNU General Public License 3 (GPL)          *\n");
     fprintf(output_fp,"*                   Start time: %s                  *\n",c_time_str);

--- a/src/lapVecNonOrth.c
+++ b/src/lapVecNonOrth.c
@@ -1414,11 +1414,8 @@ void Calc_DX1_DX2(
             int jshift_X = kshift_X + jj * stride_y_X;
             const int niters = x_DX_epos - x_DX_spos;
             #pragma omp simd
-            //for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
             for (i = 0; i < niters; i++)
             {
-                // int ishift_DX = jshift_DX + i;
-                // int ishift_X = jshift_X + ii;
                 int ishift_DX = jshift_DX + i + x_DX_spos;
                 int ishift_X  = jshift_X  + i + x_X_spos;
                 double temp1 = 0.0;
@@ -1471,17 +1468,10 @@ void stencil_4comp(
             int jshift_X1 = kshift_X1 + j * stride_y_X1;
             int jshift_X  = kshift_X + jj * stride_y_X;
             int jshift_DX = kshift_DX + jjj * stride_y_DX;
-            
-            //#pragma omp simd
-            //for (i = x_X1_spos, ii = x_X_spos, iii = x_DX_spos; i < x_X1_epos; i++, ii++, iii++)
-            
             const int niters = x_X1_epos - x_X1_spos;
             #pragma omp simd
             for (i = 0; i < niters; i++)
             {
-                // int ishift_X1    = jshift_X1 + i;
-                // int ishift_X     = jshift_X + ii;
-                // int ishift_DX    = jshift_DX + iii;
                 int ishift_X1    = jshift_X1 + i + x_X1_spos;
                 int ishift_X     = jshift_X  + i + x_X_spos;
                 int ishift_DX    = jshift_DX + i + x_DX_spos;
@@ -1545,17 +1535,12 @@ void stencil_5comp(
             int jshift_DX2 = kshift_DX2 + jjjj * stride_y_DX2;
             const int niters = x_X1_epos - x_X1_spos;
             #pragma omp simd
-            // for (i = x_X1_spos, ii = x_X_spos, iii = x_DX1_spos, iiii = x_DX2_spos; i < x_X1_epos; i++, ii++, iii++, iiii++)
             for (i = 0; i < niters; i++)
             {
-                // int ishift_X1    = jshift_X1   + i;
-                // int ishift_X     = jshift_X    + ii;
-                // int ishift_DX1    = jshift_DX1 + iii;
-                // int ishift_DX2    = jshift_DX2 + iiii;
-                int ishift_X1    = jshift_X1   + i + x_X1_spos;
-                int ishift_X     = jshift_X    + i + x_X_spos;
-                int ishift_DX1    = jshift_DX1 + i + x_DX1_spos;
-                int ishift_DX2    = jshift_DX2 + i + x_DX2_spos;
+                int ishift_X1  = jshift_X1  + i + x_X1_spos;
+                int ishift_X   = jshift_X   + i + x_X_spos;
+                int ishift_DX1 = jshift_DX1 + i + x_DX1_spos;
+                int ishift_DX2 = jshift_DX2 + i + x_DX2_spos;
                 double res = coef_0 * X[ishift_X];
                 for (r = 1; r <= radius; r++)
                 {
@@ -1612,15 +1597,11 @@ void stencil_4comp_extd(
             int jshift_DX = kshift_DX + jjj * stride_y_DX;
             const int niters = x_X1_epos - x_X1_spos;
             #pragma omp simd
-            //for (i = x_X1_spos, ii = x_X_spos, iii = x_DX_spos; i < x_X1_epos; i++, ii++, iii++)
             for (i = 0; i < niters; i++)
             {
-                // int ishift_X1    = jshift_X1 + i;
-                // int ishift_X     = jshift_X + ii;
-                // int ishift_DX    = jshift_DX + iii;
-                int ishift_X1    = jshift_X1 + i + x_X1_spos;
-                int ishift_X     = jshift_X  + i + x_X_spos;
-                int ishift_DX    = jshift_DX + i + x_DX_spos;
+                int ishift_X1 = jshift_X1 + i + x_X1_spos;
+                int ishift_X  = jshift_X  + i + x_X_spos;
+                int ishift_DX = jshift_DX + i + x_DX_spos;
                 double res = coef_0 * X[ishift_X];
                 for (r = 1; r <= radius; r++)
                 {
@@ -1682,13 +1663,8 @@ void stencil_5comp_extd(
             int jshift_DX2 = kshift_DX2 + jjjj * stride_y_DX2;
             const int niters = x_X1_epos - x_X1_spos;
             #pragma omp simd
-            //for (i = x_X1_spos, ii = x_X_spos, iii = x_DX1_spos, iiii = x_DX2_spos; i < x_X1_epos; i++, ii++, iii++, iiii++)
             for (i = 0; i < niters; i++)
             {
-                // int ishift_X1    = jshift_X1 + i;
-                // int ishift_X     = jshift_X + ii;
-                // int ishift_DX1    = jshift_DX1 + iii;
-                // int ishift_DX2    = jshift_DX2 + iiii;
                 int ishift_X1    = jshift_X1   + i + x_X1_spos;
                 int ishift_X     = jshift_X    + i + x_X_spos;
                 int ishift_DX1    = jshift_DX1 + i + x_DX1_spos;

--- a/src/lapVecNonOrthKpt.c
+++ b/src/lapVecNonOrthKpt.c
@@ -1197,12 +1197,13 @@ void Calc_DX1_DX2_kpt(
         {
             int jshift_DX = kshift_DX + j * stride_y_DX;
             int jshift_X = kshift_X + jj * stride_y_X;
-            //#pragma simd
             init1_m1 = init1_m2 = 0;
-            for (i = x_DX_spos, ii = x_X_spos; i < x_DX_epos; i++, ii++)
+            const int niters = x_DX_epos - x_DX_spos;
+            #pragma omp simd
+            for (i = 0; i < niters; i++)
             {
-                int ishift_DX = jshift_DX + i;
-                int ishift_X = jshift_X + ii;
+                int ishift_DX = jshift_DX + i + x_DX_spos;
+                int ishift_X = jshift_X + i + x_X_spos;
                 double complex temp1 = 0.0;
                 double complex temp2 = 0.0;
                 count_m1 = init1_m1 + init2_m1 + init3_m1;
@@ -1370,12 +1371,13 @@ void stencil_4comp_kpt(
             int jshift_X  = kshift_X + jj * stride_y_X;
             int jshift_DX = kshift_DX + jjj * stride_y_DX;
             countx = init1 = 0;
-            //#pragma simd
-            for (i = x_X1_spos, ii = x_X_spos, iii = x_DX_spos; i < x_X1_epos; i++, ii++, iii++)
+            const int niters = x_X1_epos - x_X1_spos;
+            #pragma omp simd
+            for (i = 0; i < niters; i++)
             {
-                int ishift_X1    = jshift_X1 + i;
-                int ishift_X     = jshift_X + ii;
-                int ishift_DX    = jshift_DX + iii;
+                int ishift_X1    = jshift_X1 + i + x_X1_spos;
+                int ishift_X     = jshift_X  + i + x_X_spos;
+                int ishift_DX    = jshift_DX + i + x_DX_spos;
                 county = count2;
                 countz = count3;
                 countm = init1 + init2 + init3;
@@ -1577,14 +1579,15 @@ void stencil_5comp_kpt(
             int jshift_X  = kshift_X + jj * stride_y_X;
             int jshift_DX1 = kshift_DX1 + jjj * stride_y_DX1;
             int jshift_DX2 = kshift_DX2 + jjjj * stride_y_DX2;
-            //#pragma simd
             countx = init1_m1 = init1_m2 = 0;
-            for (i = x_X1_spos, ii = x_X_spos, iii = x_DX1_spos, iiii = x_DX2_spos; i < x_X1_epos; i++, ii++, iii++, iiii++)
+            const int niters = x_X1_epos - x_X1_spos;
+            #pragma omp simd
+            for (i = 0; i < niters; i++)
             {
-                int ishift_X1    = jshift_X1 + i;
-                int ishift_X     = jshift_X + ii;
-                int ishift_DX1    = jshift_DX1 + iii;
-                int ishift_DX2    = jshift_DX2 + iiii;
+                int ishift_X1  = jshift_X1  + i + x_X1_spos;
+                int ishift_X   = jshift_X   + i + x_X_spos;
+                int ishift_DX1 = jshift_DX1 + i + x_DX1_spos;
+                int ishift_DX2 = jshift_DX2 + i + x_DX2_spos;
                 county = count2;
                 countz = count3;
                 countm1 = init1_m1 + init2_m1 + init3_m1;


### PR DESCRIPTION
1. Add simd instructions for Laplacian vector routines for k-points (works well for intel/19.0.5 with automatic cpu dispatch).